### PR TITLE
tweak make-fat-image.sh; fix Xen+FAT broken builds

### DIFF
--- a/lib/main.ml
+++ b/lib/main.ml
@@ -71,9 +71,9 @@ let configure =
   let configure unix xen socket no_opam file =
     if unix && xen then `Help (`Pager, Some "configure")
     else
+      let _ = Mirage.set_mode (mode unix xen socket) in
       let t = Mirage.load file in
       Mirage.manage_opam_packages (not no_opam);
-      Mirage.set_mode (mode unix xen socket);
       `Ok (Mirage.configure t) in
   Term.(ret (pure configure $ unix $ xen $ socket $ no_opam $ file)),
   term_info "configure" ~doc ~man

--- a/lib/mirage.ml
+++ b/lib/mirage.ml
@@ -531,7 +531,7 @@ type block = BLOCK
 
 let block = Type BLOCK
 
-let block_of_file: string -> block impl =
+let block_of_file () : string -> block impl =
   function filename ->
     impl block filename (module Block)
 
@@ -587,8 +587,8 @@ let fat: block impl -> fs impl =
     impl fs block (module Fat)
 
 (* This would deserve to be in its own lib. *)
-let kv_ro_of_fs =
-  let dummy_fat = fat (block_of_file "xx") in
+let kv_ro_of_fs () =
+  let dummy_fat = fat (block_of_file () "xx") in
   let libraries = Impl.libraries dummy_fat in
   let packages = Impl.packages dummy_fat in
   let fn = foreign "Fat.KV_RO.Make" ~libraries ~packages (fs @-> kv_ro) in
@@ -613,7 +613,7 @@ module Fat_of_files = struct
     name t ^ ".img"
 
   let block t =
-    block_of_file (block_file t)
+    block_of_file () (block_file t)
 
   let packages t =
     Fat.packages (block t)

--- a/lib/mirage.mli
+++ b/lib/mirage.mli
@@ -89,7 +89,7 @@ type block
 val block: block typ
 (** Representation of [Mirage_types.BLOCK]. *)
 
-val block_of_file: string -> block impl
+val block_of_file: unit -> string -> block impl
 (** Use the given filen as a raw block device. *)
 
 type fs
@@ -107,7 +107,7 @@ val fat_of_files: ?dir:string -> ?regexp:string -> unit -> fs impl
     image. By default, [dir] is the current working directory and
     [regexp] is {i *} *)
 
-val kv_ro_of_fs: fs impl -> kv_ro impl
+val kv_ro_of_fs: unit -> fs impl -> kv_ro impl
 (** Consider a filesystem implementation as a read-only key/value
     store. *)
 


### PR DESCRIPTION
use of `KiB` requires accepting my PR to `mirage/ocaml-fat`

i'm trying here to construct a FAT image that's of the correct size for the directory that will be copied in.

i pay no attention to the effect of the regex :)

see comment below re fixing broken builds
